### PR TITLE
Variable render_at not being passed down accordingly.

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -169,8 +169,8 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
     return this.store[method].call(this, options || {});
   },
 
-  renderBlock: function(block) {
-    this._renderInPosition(block.render().$el);
+  renderBlock: function(block, render_at) {
+    this._renderInPosition(block.render().$el, render_at);
     this.hideAllTheThings();
     this.scrollTo(block.$el);
 


### PR DESCRIPTION
Variable render_at needs to be passed down so that in situations such as when nested blocks are loaded as part of the initial editor loading, that they are properly positioned. Otherwise, they will appear in the incorrect location.