### PR TITLE
Return block on creation

### DIFF
--- a/src/block-manager.js
+++ b/src/block-manager.js
@@ -61,6 +61,8 @@ Object.assign(BlockManager.prototype, require('./function-bind'), require('./med
 
     EventBus.trigger(data ? "block:create:existing" : "block:create:new", block);
     utils.log("Block created of type " + type);
+
+    return block;
   },
 
   removeBlock: function(blockID) {


### PR DESCRIPTION
We need to return the block on creation. This will allow the columns block to properly place blocks in columns into the right order. Otherwise, the contents of column blocks is populated with blocks in reverse order.